### PR TITLE
Require Python 3.10 or later

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "django-rusty-templates"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Django 5.x has a minimum Python version of 3.10.

A clone of https://github.com/LilyAcorn/django-rusty-templates/pull/94 for testing purposes.