### PR TITLE
Add a justfile with local coverage commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,21 @@
+python-coverage:
+    maturin develop
+    pytest --cov
+
+rust-coverage:
+    #!/usr/bin/bash
+    cargo llvm-cov clean --workspace
+    cargo llvm-cov --no-report
+    source <(cargo llvm-cov show-env --export-prefix)
+    maturin develop
+    pytest
+    cargo llvm-cov report
+
+rust-coverage-browser:
+    #!/usr/bin/bash
+    cargo llvm-cov clean --workspace
+    cargo llvm-cov --no-report
+    source <(cargo llvm-cov show-env --export-prefix)
+    maturin develop
+    pytest
+    cargo llvm-cov report --open


### PR DESCRIPTION
This allows viewing Rust (and Python) coverage locally without jumping through hoops to configure environment variables and combine coverage files.