### PR TITLE
Set coverage env vars before running rust tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,8 +5,8 @@ python-coverage:
 rust-coverage:
     #!/usr/bin/bash
     cargo llvm-cov clean --workspace
-    cargo llvm-cov --no-report
     source <(cargo llvm-cov show-env --export-prefix)
+    cargo llvm-cov --no-report
     maturin develop
     pytest
     cargo llvm-cov report
@@ -14,8 +14,8 @@ rust-coverage:
 rust-coverage-browser:
     #!/usr/bin/bash
     cargo llvm-cov clean --workspace
-    cargo llvm-cov --no-report
     source <(cargo llvm-cov show-env --export-prefix)
+    cargo llvm-cov --no-report
     maturin develop
     pytest
     cargo llvm-cov report --open


### PR DESCRIPTION
While `cargo llvm-cov` works without setting these environment variables, this led to the report not finding the data for the Rust unit tests.