### PR TITLE
Fix missing resolver_match introspection for {% url %} tag

### DIFF
--- a/src/render/tags.rs
+++ b/src/render/tags.rs
@@ -30,8 +30,8 @@ fn current_app(py: Python, request: &Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
         .getattr(py, "resolver_match")
         .ok_or_isinstance_of::<PyAttributeError>(py)?
     {
-        Ok(resolver_match) => resolver_match.getattr(py, "namespace"),
-        Err(_) => Ok(none),
+        Ok(resolver_match) if !resolver_match.is_none(py) => resolver_match.getattr(py, "namespace"),
+        _ => Ok(none),
     }
 }
 

--- a/tests/tags/test_url.py
+++ b/tests/tags/test_url.py
@@ -6,6 +6,9 @@ from django.test import RequestFactory
 from django.urls import resolve, NoReverseMatch
 
 
+factory = RequestFactory()
+
+
 def test_render_url():
     template = "{% url 'home' %}"
     django_template = engines["django"].from_string(template)
@@ -97,7 +100,7 @@ def test_render_url_current_app_unset():
     django_template = engines["django"].from_string(template)
     rust_template = engines["rusty"].from_string(template)
 
-    request = RequestFactory()
+    request = factory.get('/')
 
     expected = "/users/lily/"
     assert django_template.render({}, request) == expected
@@ -109,7 +112,7 @@ def test_render_url_current_app():
     django_template = engines["django"].from_string(template)
     rust_template = engines["rusty"].from_string(template)
 
-    request = RequestFactory()
+    request = factory.get('/')
     request.current_app = "members"
 
     expected = "/members/lily/"
@@ -122,7 +125,7 @@ def test_render_url_current_app_kwargs():
     django_template = engines["django"].from_string(template)
     rust_template = engines["rusty"].from_string(template)
 
-    request = RequestFactory()
+    request = factory.get('/')
     request.current_app = "members"
 
     expected = "/members/lily/"
@@ -135,7 +138,7 @@ def test_render_url_current_app_resolver_match():
     django_template = engines["django"].from_string(template)
     rust_template = engines["rusty"].from_string(template)
 
-    request = RequestFactory()
+    request = factory.get('/')
     request.resolver_match = resolve("/members/bryony/")
 
     expected = "/members/lily/"


### PR DESCRIPTION
The url tag tests were using `RequestFactory` incorrectly, masking this bug.